### PR TITLE
server: test the distributed engine by script

### DIFF
--- a/common/src/request.rs
+++ b/common/src/request.rs
@@ -25,6 +25,8 @@ pub enum OperationType {
     OpenFile = 5,
     ReadFile = 6,
     WriteFile = 7,
+    DeleteFile = 8,
+    DeleteDir = 9,
 }
 
 impl TryFrom<u32> for OperationType {
@@ -39,6 +41,8 @@ impl TryFrom<u32> for OperationType {
             5 => Ok(OperationType::OpenFile),
             6 => Ok(OperationType::ReadFile),
             7 => Ok(OperationType::WriteFile),
+            8 => Ok(OperationType::DeleteFile),
+            9 => Ok(OperationType::DeleteDir),
             _ => panic!("Unkown value: {}", value),
         }
     }

--- a/server/src/distributed_engine/engine_rpc.rs
+++ b/server/src/distributed_engine/engine_rpc.rs
@@ -1,7 +1,7 @@
 use self::enginerpc::{
     enginerpc_server::Enginerpc, enginerpc_server::EnginerpcServer, EngineRequest, EngineResponse,
 };
-
+use std::sync::Arc;
 use crate::storage_engine::StorageEngine;
 use tonic::{Request, Response, Status};
 pub mod enginerpc {
@@ -9,7 +9,7 @@ pub mod enginerpc {
 }
 
 pub struct RPCService<Storage: StorageEngine> {
-    pub local_storage: Storage,
+    pub local_storage: Arc<Storage>,
 }
 
 pub fn new_manager_service<
@@ -20,7 +20,7 @@ pub fn new_manager_service<
     EnginerpcServer::new(service)
 }
 impl<Storage: StorageEngine> RPCService<Storage> {
-    pub fn new(local_storage: Storage) -> Self {
+    pub fn new(local_storage: Arc<Storage>) -> Self {
         Self { local_storage }
     }
 }
@@ -33,8 +33,6 @@ impl<Storage: StorageEngine + std::marker::Send + std::marker::Sync + 'static> E
         request: Request<EngineRequest>,
     ) -> Result<Response<EngineResponse>, Status> {
         let message = request.get_ref();
-        println!("parentdir: {}", message.parentdir.clone());
-        println!("filename: {}", message.filename.clone());
         let result = self
             .local_storage
             .directory_add_entry(message.parentdir.clone(), message.filename.clone());

--- a/server_test.py
+++ b/server_test.py
@@ -1,0 +1,171 @@
+
+import unittest
+import socket
+import struct
+import yaml
+import os
+
+
+class op_type():
+    CreateFile = 1
+    CreateDir = 2
+    GetFileAttr = 3
+    ReadDir = 4
+    OpenFile = 5
+    ReadFile = 6
+    WriteFile = 7
+    DeleteFile = 8
+    DeleteDir = 9
+
+
+def make_body(filepath):
+    utf8_filepath = bytes(filepath, encoding='utf-8')
+    filelen = struct.pack("I", len(utf8_filepath))
+    return filelen + utf8_filepath
+
+
+def make_header(type, body_len):
+    id = 0
+    flag = 0
+    total_length = body_len + 16
+    header = struct.pack("4I", id, type, flag, total_length)
+    return header
+
+
+def get_status(client):
+    response = client.recv(1024)
+    _, status, _, _ = struct.unpack("4I", response)
+    return status
+
+
+def send_request(index, type, filepath):
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(address[index])
+    body = make_body(filepath)
+    header = make_header(type, len(body))
+    request = header + body
+    client.send(request)
+    return client
+
+
+# hash
+dic = {
+    '/': 1,
+    '/t1.txt': 1,
+    '/test1/': 1,
+    '/test1/t1.txt': 2,
+    '/test1/test_dir/': 2,
+}
+address = [('127.0.0.1', 8085), ('127.0.0.1', 8086), ('127.0.0.1', 8087)]
+
+
+class TestDistributed_engine(unittest.TestCase):
+    def test_file(self):
+        path = '/t1.txt'
+        client = send_request(dic[path], op_type.CreateFile, path)
+        self.assertEqual(0, get_status(client))
+
+        client = send_request(dic[path], op_type.CreateFile, path)
+        self.assertNotEqual(0, get_status(client))
+
+        client = send_request(dic[path], op_type.DeleteFile, path)
+        self.assertEqual(0, get_status(client))
+
+    def test_dir1(self):
+        path = '/test1/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertEqual(0, get_status(client))
+
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertNotEqual(0, get_status(client))
+
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/test_dir/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertNotEqual(0, get_status(client))
+
+    def test_dir2(self):
+        path = '/test1/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/test_dir/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertNotEqual(0, get_status(client))
+
+        path = '/test1/test_dir/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertEqual(0, get_status(client))
+
+    def test_all(self):
+        path = '/test1/t1.txt'
+        client = send_request(dic[path], op_type.CreateFile, path)
+        self.assertNotEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/t1.txt'
+        client = send_request(dic[path], op_type.CreateFile, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/test_dir/'
+        client = send_request(dic[path], op_type.CreateDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertNotEqual(0, get_status(client))
+
+        path = '/test1/t1.txt'
+        client = send_request(dic[path], op_type.DeleteFile, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertNotEqual(0, get_status(client))
+
+        path = '/test1/test_dir/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertEqual(0, get_status(client))
+
+        path = '/test1/'
+        client = send_request(dic[path], op_type.DeleteDir, path)
+        self.assertEqual(0, get_status(client))
+
+# path = '/t1.txt'
+# client = send_request(dic[path], op_type.DeleteFile, path)
+# print(get_status(client))
+# client.close()
+
+# path = '/test1/t1.txt'
+# client = send_request(dic[path], op_type.DeleteFile, path)
+# path = '/test1/test_dir/'
+# client = send_request(dic[path], op_type.DeleteDir, path)
+# path = '/test1/'
+# client = send_request(dic[path], op_type.DeleteDir, path)
+# path = '/t1.txt'
+# client = send_request(dic[path], op_type.DeleteFile, path)
+
+
+path = '/test1/t1.txt'
+client = send_request(dic[path], op_type.DeleteFile, path)
+
+path = '/test1/test_dir/'
+client = send_request(dic[path], op_type.DeleteDir, path)
+
+path = '/test1/'
+client = send_request(dic[path], op_type.DeleteDir, path)
+
+unittest.main(warnings='ignore')

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -19,6 +19,8 @@ struct Properties {
     lifetime: String,
     database_path: String,
     storage_path: String,
+    local_distributed_address: String,
+    all_distributed_address: Vec<String>,
 }
 
 pub mod manager_service {
@@ -58,12 +60,12 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
     //     .set_serving::<RemoteFsServer<FsService>>()
     //     .await;
     info!("Start Server");
-    // TO DO get index
     server::run(
-        0,
         properties.server_address.clone(),
         properties.database_path.clone(),
         properties.storage_path.clone(),
+        properties.local_distributed_address.clone(),
+        properties.all_distributed_address.clone(),
     )
     .await?;
     // Server::builder()

--- a/test_yaml/server0.yaml
+++ b/test_yaml/server0.yaml
@@ -1,0 +1,16 @@
+manager_address:
+  127.0.0.1:8081
+server_address:
+  127.0.0.1:8085
+lifetime:
+  long
+database_path:
+  /tmp/database0/
+storage_path:
+  /tmp/storage0/
+local_distributed_address:
+  127.0.0.1:8090
+all_distributed_address:
+ - 127.0.0.1:8090
+ - 127.0.0.1:8091
+ - 127.0.0.1:8092

--- a/test_yaml/server1.yaml
+++ b/test_yaml/server1.yaml
@@ -1,0 +1,16 @@
+manager_address:
+  127.0.0.1:8081
+server_address:
+  127.0.0.1:8086
+lifetime:
+  long
+database_path:
+  /tmp/database1/
+storage_path:
+  /tmp/storage1/
+local_distributed_address:
+  127.0.0.1:8091
+all_distributed_address:
+ - 127.0.0.1:8090
+ - 127.0.0.1:8091
+ - 127.0.0.1:8092

--- a/test_yaml/server2.yaml
+++ b/test_yaml/server2.yaml
@@ -1,0 +1,16 @@
+manager_address:
+  127.0.0.1:8081
+server_address:
+  127.0.0.1:8087
+lifetime:
+  long
+database_path:
+  /tmp/database2/
+storage_path:
+  /tmp/storage2/
+local_distributed_address:
+  127.0.0.1:8092
+all_distributed_address:
+ - 127.0.0.1:8090
+ - 127.0.0.1:8091
+ - 127.0.0.1:8092


### PR DESCRIPTION
* server: test the distributed engine by script

* fix: delete_dir function use directory_delete_entry, instead of directory_add_entry

* fix: use hash get address, instead of index

* directory empty implemented in delete_directory function

* add some case for OperationType

* add some case for EngineErr2Status temporarily


Test Steps:

You need to run manager
You need to run three different servers, you need to manually replace the configuration file and start it three times (refer to the three configuration files in the test_yaml directory)
run server_test.py to test