### PR TITLE
rpc: client uses tokio instead

### DIFF
--- a/examples/hello_client_async.rs
+++ b/examples/hello_client_async.rs
@@ -1,0 +1,61 @@
+#[macro_use]
+extern crate lazy_static;
+use std::sync::Arc;
+
+use log::debug;
+use rpc::client::ClientAsync;
+
+lazy_static! {
+    static ref CLIENT: Arc<ClientAsync> = Arc::new(ClientAsync::new());
+}
+
+#[tokio::main]
+pub async fn main() {
+    let mut builder = env_logger::Builder::from_default_env();
+    builder
+        .format_timestamp(None)
+        .filter(None, log::LevelFilter::Debug);
+    builder.init();
+
+    CLIENT.add_connection(0, "127.0.0.1:50051").await;
+    for i in 0..50 {
+        let new_client = CLIENT.clone();
+        tokio::spawn(async move {
+            let mut status = 0;
+            let mut rsp_flags = 0;
+            let mut recv_meta_data = vec![];
+            let mut recv_data = vec![0u8; 1024];
+            debug!("call_remote, start");
+            let result = new_client
+                .call_remote(
+                    0,
+                    0,
+                    0,
+                    "",
+                    &[],
+                    &[],
+                    &mut status,
+                    &mut rsp_flags,
+                    &mut recv_meta_data,
+                    &mut recv_data,
+                )
+                .await;
+            debug!("call_remote, result: {:?}", result);
+            match result {
+                Ok(_) => {
+                    if status == 0 {
+                        let data = String::from_utf8(recv_data).unwrap();
+                        println!("result: {}, data: {}", i, data);
+                    } else {
+                        println!("Error: {}", status);
+                    }
+                }
+                Err(e) => {
+                    println!("Error: {}", e);
+                }
+            }
+        });
+    }
+    std::thread::sleep(std::time::Duration::from_secs(60));
+    println!("Done")
+}

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::connection::{CircularQueue, ClientConnection};
+use crate::connection::{CircularQueue, ClientConnection, ClientConnectionAsync};
 use dashmap::DashMap;
 use log::debug;
 use std::sync::Arc;
-
+use tokio::net::tcp::OwnedReadHalf;
 pub struct Client {
     connections: DashMap<i32, Arc<ClientConnection>>,
     queue: CircularQueue,
@@ -177,6 +177,205 @@ impl Client {
                 std::io::ErrorKind::Other,
                 "Error registering callback",
             ))),
+        }
+    }
+}
+
+pub struct ClientAsync {
+    connections: DashMap<i32, Arc<ClientConnectionAsync>>,
+    queue: CircularQueue,
+}
+
+impl Default for ClientAsync {
+    fn default() -> Self {
+        Self {
+            connections: DashMap::new(),
+            queue: CircularQueue::new(),
+        }
+    }
+}
+
+impl ClientAsync {
+    pub fn new() -> Self {
+        let mut queue = CircularQueue::new();
+        queue.init();
+        Self {
+            connections: DashMap::new(),
+            queue,
+        }
+    }
+    // Client must be static to tokio::spawn
+    pub async fn add_connection(&'static self, connection_id: i32, server_address: &str) {
+        let result = tokio::net::TcpStream::connect(server_address).await;
+        let connection = match result {
+            Ok(stream) => {
+                debug!("connect success");
+                let (read_stream, write_stream) = stream.into_split();
+                tokio::spawn(self.parse_response(connection_id, read_stream));
+                Arc::new(ClientConnectionAsync::new(
+                    server_address,
+                    Some(tokio::sync::Mutex::new(write_stream)),
+                ))
+            }
+            Err(e) => {
+                debug!("connect error: {}", e);
+                Arc::new(ClientConnectionAsync::new(server_address, None))
+            }
+        };
+        self.connections.insert(connection_id, connection);
+    }
+
+    pub fn remove_connection(&self, connection_id: i32) {
+        self.connections.remove(&connection_id);
+    }
+
+    // parse_response
+    // try to get response from sequence of connections and write to callbacks
+    pub async fn parse_response(&self, connection_id: i32, mut read_stream: OwnedReadHalf) {
+        loop {
+            let connection = match self.connections.get(&connection_id) {
+                Some(connection) => connection,
+                None => {
+                    return;
+                }
+            };
+            debug!("parse_response: {:?}", connection.server_address);
+            let result = connection.receive_response_header(&mut read_stream).await;
+            match result {
+                Ok(header) => {
+                    let id = header.id;
+                    let total_length = header.total_length;
+                    let meta_data_result = {
+                        match self
+                            .queue
+                            .get_meta_data_ref(id, header.meta_data_length as usize)
+                        {
+                            Ok(meta_data_result) => Ok(meta_data_result),
+                            Err(_) => Err("meta_data_result error"),
+                        }
+                    };
+                    let data_result = {
+                        match self.queue.get_data_ref(id, header.data_length as usize) {
+                            Ok(data_result) => Ok(data_result),
+                            Err(_) => Err("data_result error"),
+                        }
+                    };
+
+                    match (data_result, meta_data_result) {
+                        (Ok(data), Ok(meta_data)) => {
+                            let response = connection
+                                .receive_response(&mut read_stream, data, meta_data)
+                                .await;
+                            match response {
+                                Ok(_) => {
+                                    let result = self.queue.response(id, 0);
+                                    match result {
+                                        Ok(_) => {
+                                            debug!("Response success");
+                                        }
+                                        Err(e) => {
+                                            debug!("Error writing response back: {}", e);
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    debug!("Error receiving response: {}", e);
+                                }
+                            }
+                        }
+                        _ => {
+                            let result = connection
+                                .clean_response(&mut read_stream, total_length)
+                                .await;
+                            match result {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    debug!("Error cleaning up response: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!("Error parsing header: {}", e);
+                }
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn call_remote(
+        &self,
+        connection_index: i32,
+        operation_type: u32,
+        req_flags: u32,
+        path: &str,
+        send_meta_data: &[u8],
+        send_data: &[u8],
+        status: &mut i32,
+        rsp_flags: &mut u32,
+        recv_meta_data: &mut [u8],
+        recv_data: &mut [u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        debug!("call_remote on connection: {}", connection_index);
+        let connection = self.connections.get(&connection_index).unwrap();
+        debug!(
+            "call_remote on connection: {:?}",
+            connection.value().server_address
+        );
+        let result = {
+            match self.queue.register_callback(recv_meta_data, recv_data) {
+                Ok(result) => Ok(result),
+                Err(_) => Err("register_callback error"),
+            }
+        };
+
+        debug!("call_remote on connection: {:?}", result);
+        match result {
+            Ok(id) => {
+                let send_result = connection
+                    .send_request(
+                        id,
+                        operation_type,
+                        req_flags,
+                        path,
+                        send_meta_data,
+                        send_data,
+                    )
+                    .await;
+                match send_result {
+                    Ok(_) => {
+                        let result = self.queue.wait_for_callback(id);
+                        match result {
+                            Ok(_) => {
+                                *status = self.queue.get_status(id).unwrap();
+                                *rsp_flags = self.queue.get_rsp_flags(id).unwrap();
+                                Ok(())
+                            }
+                            Err(_) => {
+                                self.queue.error(id)?;
+                                Err(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    "Error waiting for callback",
+                                )
+                                .into())
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        self.queue.error(id)?;
+                        Err(
+                            std::io::Error::new(std::io::ErrorKind::Other, "Error sending request")
+                                .into(),
+                        )
+                    }
+                }
+            }
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Error registering callback",
+            )
+            .into()),
         }
     }
 }

--- a/rpc/src/connection.rs
+++ b/rpc/src/connection.rs
@@ -22,6 +22,7 @@ use tokio::{
 //     io::{AsyncReadExt, AsyncWriteExt},
 //     net::TcpStream,
 // };
+use anyhow::Result;
 
 enum ConnectionStatus {
     Connected = 0,
@@ -168,6 +169,155 @@ impl ClientConnection {
     pub fn clean_response(&self, total_length: u32) -> Result<(), Box<dyn std::error::Error>> {
         let mut buffer = vec![0u8; total_length as usize];
         self.receive(&mut buffer)?;
+        Ok(())
+    }
+}
+
+pub struct ClientConnectionAsync {
+    pub server_address: String,
+    write_stream: Option<tokio::sync::Mutex<OwnedWriteHalf>>,
+    status: RwLock<ConnectionStatus>,
+    // lock for send_request
+    // we need this lock because we will send multiple requests in parallel
+    // and each request will be sent several data packets due to the partation of data and header.
+    // now we simply copy the data and header to a buffer and send it in one write call,
+    // so we do not need to lock the stream(linux kernel will do it for us).
+    _send_lock: Mutex<()>,
+}
+
+impl ClientConnectionAsync {
+    pub fn new(
+        server_address: &str,
+        write_stream: Option<tokio::sync::Mutex<OwnedWriteHalf>>,
+    ) -> Self {
+        Self {
+            server_address: server_address.to_string(),
+            write_stream,
+            status: RwLock::new(ConnectionStatus::Disconnected),
+            _send_lock: Mutex::new(()),
+        }
+    }
+
+    pub fn disconnect(&mut self) {
+        self.write_stream = None;
+        *self.status.write().unwrap() = ConnectionStatus::Disconnected;
+    }
+
+    pub fn is_connected(&self) -> bool {
+        match *self.status.read().unwrap() {
+            ConnectionStatus::Connected => true,
+            ConnectionStatus::Disconnected => false,
+        }
+    }
+
+    // request
+    // | id | type | flags | total_length | file_path_length | meta_data_length | data_length | filename | meta_data | data |
+    // | 4Byte | 4Byte | 4Byte | 4Byte | 4Byte | 4Byte | 4Byte | 1~4kB | 0~ | 0~ |
+    pub async fn send_request(
+        &self,
+        id: u32,
+        operation_type: u32,
+        flags: u32,
+        filename: &str,
+        meta_data: &[u8],
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let filename_length = filename.len();
+        let meta_data_length = meta_data.len();
+        let data_length = data.len();
+        let total_length = filename_length + meta_data_length + data_length;
+        debug!(
+            "total_length: {}, filename_length: {}, meta_data_length: {}, data_length: {}",
+            total_length, filename_length, meta_data_length, data_length
+        );
+        let mut request = Vec::with_capacity(total_length + REQUEST_HEADER_SIZE);
+        request.extend_from_slice(&id.to_le_bytes());
+        request.extend_from_slice(&operation_type.to_le_bytes());
+        request.extend_from_slice(&flags.to_le_bytes());
+        request.extend_from_slice(&(total_length as u32).to_le_bytes());
+        request.extend_from_slice(&(filename_length as u32).to_le_bytes());
+        request.extend_from_slice(&(meta_data_length as u32).to_le_bytes());
+        request.extend_from_slice(&(data_length as u32).to_le_bytes());
+        request.extend_from_slice(filename.as_bytes());
+        request.extend_from_slice(meta_data);
+        request.extend_from_slice(data); // Here we copy data to request instead of locking the stream, but it is not sufficient.
+        debug!("request: {:?}", request);
+        self.write_stream
+            .as_ref()
+            .unwrap()
+            .lock()
+            .await
+            .write_all(&request)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn receive_response_header(
+        &self,
+        read_stream: &mut OwnedReadHalf,
+    ) -> Result<ResponseHeader> {
+        let mut header = [0; RESPONSE_HEADER_SIZE];
+        self.receive(read_stream, &mut header).await?;
+        debug!("header: {:?}", header);
+        let id = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        let status = i32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+        let flags = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
+        let total_length = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
+        let meta_data_length = u32::from_le_bytes([header[16], header[17], header[18], header[19]]);
+        let data_length = u32::from_le_bytes([header[20], header[21], header[22], header[23]]);
+        debug!(
+            "id: {}, status: {}, flags: {}, total_length: {}, meta_data_length: {}, data_length: {}",
+            id, status, flags, total_length, meta_data_length, data_length
+        );
+        Ok(ResponseHeader {
+            id,
+            status,
+            flags,
+            total_length,
+            meta_data_length,
+            data_length,
+        })
+    }
+
+    pub async fn receive_response(
+        &self,
+        read_stream: &mut OwnedReadHalf,
+        data: &mut [u8],
+        meta_data: &mut [u8],
+    ) -> Result<()> {
+        let data_length = data.len();
+        let meta_data_length = meta_data.len();
+        self.receive(read_stream, &mut data[0..data_length as usize])
+            .await?;
+        self.receive(read_stream, &mut meta_data[0..meta_data_length as usize])
+            .await?;
+        Ok(())
+    }
+
+    pub async fn receive(&self, read_stream: &mut OwnedReadHalf, data: &mut [u8]) -> Result<()> {
+        let mut buf_len = 0;
+        debug!("waiting for response, data length: {}", data.len());
+        let result = read_stream.read(data).await;
+        match result {
+            Ok(len) => {
+                buf_len += len;
+                debug!("received {} bytes, total: {}", len, buf_len);
+            }
+            Err(_) => {
+                return Err(anyhow::anyhow!("failed to receive response"));
+            }
+        }
+        debug!("received response, data length: {}", buf_len);
+        Ok(())
+    }
+
+    pub async fn clean_response(
+        &self,
+        read_stream: &mut OwnedReadHalf,
+        total_length: u32,
+    ) -> Result<()> {
+        let mut buffer = vec![0u8; total_length as usize];
+        self.receive(read_stream, &mut buffer).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
* tokio spawn when add_connection is called

* use anyhow::Result temporarily

* client should be declared as a static variable