### PR TITLE
reading from the command line for ./manager and ./server

### DIFF
--- a/src/bin/manager.rs
+++ b/src/bin/manager.rs
@@ -2,9 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use sealfs::{manager::manager_service::ManagerService, rpc::server::Server};
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::{fmt::Debug, sync::Arc};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(long)]
+    address: Option<String>,
+    #[arg(long)]
+    protect_threshold: Option<String>,
+    #[arg(long)]
+    config_file: Option<String>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Properties {
@@ -19,9 +32,33 @@ async fn main() -> anyhow::Result<()> {
         .format_timestamp(None)
         .filter(None, log::LevelFilter::Debug);
     builder.init();
-    //read from yaml.
-    let yaml_str = include_str!("../../examples/manager.yaml");
-    let properties: Properties = serde_yaml::from_str(yaml_str).expect("manager.yaml read failed!");
+    let mut properties: Properties;
+    // read from command line.
+    let args = Args::parse();
+    // if the user provides the config file, parse it and use the arguments from the config file.
+    match args.config_file {
+        None => {
+            //read from default configuration.
+            let yaml_str = include_str!("../../examples/manager.yaml");
+            properties = serde_yaml::from_str(yaml_str).expect("manager.yaml read failed!");
+        }
+        Some(c) => {
+            // read from user-provided config file
+            let yaml_str = fs::read_to_string(c).expect("Couldn't read from file. The file is either missing or you don't have enough permissions!");
+            properties = serde_yaml::from_str(&yaml_str).expect("server.yaml read failed!");
+        }
+    }
+    properties.address = if let Some(addr) = args.address {
+        addr
+    } else {
+        properties.address
+    };
+    properties.protect_threshold = if let Some(t) = args.protect_threshold {
+        t
+    } else {
+        properties.protect_threshold
+    };
+
     let address = properties.address;
 
     let server = Server::new(Arc::new(ManagerService::default()), &address);

--- a/src/bin/manager.rs
+++ b/src/bin/manager.rs
@@ -63,10 +63,10 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         false => Properties {
-            address: args.address.unwrap_or_else(|| default_properties.address),
+            address: args.address.unwrap_or(default_properties.address),
             protect_threshold: args
                 .protect_threshold
-                .unwrap_or_else(|| default_properties.protect_threshold),
+                .unwrap_or(default_properties.protect_threshold),
         },
     };
 

--- a/src/bin/manager.rs
+++ b/src/bin/manager.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use log::warn;
 use sealfs::{manager::manager_service::ManagerService, rpc::server::Server};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::{fmt::Debug, sync::Arc};
-use log::warn;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -55,15 +55,15 @@ async fn main() -> anyhow::Result<()> {
                     result
                 }
                 _ => {
-                    warn!("No custom configuration provided, fallback to the default configuration.");
+                    warn!(
+                        "No custom configuration provided, fallback to the default configuration."
+                    );
                     default_properties
                 }
             }
         }
         false => Properties {
-            address: args
-                .address
-                .unwrap_or_else(|| default_properties.address),
+            address: args.address.unwrap_or_else(|| default_properties.address),
             protect_threshold: args
                 .protect_threshold
                 .unwrap_or_else(|| default_properties.protect_threshold),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -90,24 +90,24 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
         false => Properties {
             manager_address: args
                 .manager_address
-                .unwrap_or_else(|| default_properties.manager_address),
+                .unwrap_or(default_properties.manager_address),
             server_address: args
                 .server_address
-                .unwrap_or_else(|| default_properties.server_address),
+                .unwrap_or(default_properties.server_address),
             all_servers_address: args
                 .all_servers_address
-                .unwrap_or_else(|| default_properties.all_servers_address),
+                .unwrap_or(default_properties.all_servers_address),
 
-            lifetime: args.lifetime.unwrap_or_else(|| default_properties.lifetime),
+            lifetime: args.lifetime.unwrap_or(default_properties.lifetime),
             database_path: args
                 .database_path
-                .unwrap_or_else(|| default_properties.database_path),
+                .unwrap_or(default_properties.database_path),
             storage_path: args
                 .storage_path
-                .unwrap_or_else(|| default_properties.storage_path),
+                .unwrap_or(default_properties.storage_path),
             heartbeat: args
                 .heartbeat
-                .unwrap_or_else(|| default_properties.heartbeat),
+                .unwrap_or(default_properties.heartbeat),
         },
     };
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -102,12 +102,8 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
             database_path: args
                 .database_path
                 .unwrap_or(default_properties.database_path),
-            storage_path: args
-                .storage_path
-                .unwrap_or(default_properties.storage_path),
-            heartbeat: args
-                .heartbeat
-                .unwrap_or(default_properties.heartbeat),
+            storage_path: args.storage_path.unwrap_or(default_properties.storage_path),
+            heartbeat: args.heartbeat.unwrap_or(default_properties.heartbeat),
         },
     };
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -62,7 +62,8 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
 
     // read from default configuration.
     let default_yaml_str = include_str!("../../examples/server.yaml");
-    let default_properties: Properties = serde_yaml::from_str(default_yaml_str).expect("server.yaml read failed!");
+    let default_properties: Properties =
+        serde_yaml::from_str(default_yaml_str).expect("server.yaml read failed!");
 
     // read from command line.
     let args: Args = Args::parse();
@@ -79,22 +80,35 @@ async fn main() -> anyhow::Result<(), Box<dyn std::error::Error>> {
                     result
                 }
                 _ => {
-                    warn!("No custom configuration provided, fallback to the default configuration.");
-                        default_properties
+                    warn!(
+                        "No custom configuration provided, fallback to the default configuration."
+                    );
+                    default_properties
                 }
             }
-
         }
         false => Properties {
-            manager_address: args.manager_address.unwrap_or_else(|| default_properties.manager_address),
-            server_address: args.server_address.unwrap_or_else(|| default_properties.server_address),
-            all_servers_address: args.all_servers_address.unwrap_or_else(|| default_properties.all_servers_address),
+            manager_address: args
+                .manager_address
+                .unwrap_or_else(|| default_properties.manager_address),
+            server_address: args
+                .server_address
+                .unwrap_or_else(|| default_properties.server_address),
+            all_servers_address: args
+                .all_servers_address
+                .unwrap_or_else(|| default_properties.all_servers_address),
 
             lifetime: args.lifetime.unwrap_or_else(|| default_properties.lifetime),
-            database_path: args.database_path.unwrap_or_else(|| default_properties.database_path),
-            storage_path: args.storage_path.unwrap_or_else(|| default_properties.storage_path),
-            heartbeat: args.heartbeat.unwrap_or_else(|| default_properties.heartbeat)
-        }
+            database_path: args
+                .database_path
+                .unwrap_or_else(|| default_properties.database_path),
+            storage_path: args
+                .storage_path
+                .unwrap_or_else(|| default_properties.storage_path),
+            heartbeat: args
+                .heartbeat
+                .unwrap_or_else(|| default_properties.heartbeat),
+        },
     };
 
     let manager_address = properties.manager_address;


### PR DESCRIPTION
Since sealfs already depends on `clap`, the command line support is implemented using this library.
This commit separates Args and Properties structures. This way, it's more convenient to add more arguments in the future without restructuring Properties.