### PR TITLE
chore: add libibverbs dependency to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ deps = 	protobuf-compiler	\
 		libfuse-dev			\
 		libcapstone-dev		\
 		iproute2 perftest build-essential net-tools \
-		cython pandoc libnl-3-dev libnl-route-3-dev
+		cython pandoc libnl-3-dev libnl-route-3-dev libibverbs-dev
 
 all_release: install_deps release
 all_debug: install_deps debug


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Add libibverbs-dev to the makefile to ensure a successful compilation

#### Which issue(s) this PR fixes:
Fixes #147 
